### PR TITLE
smemstat.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/smemstat.c
+++ b/smemstat.c
@@ -345,7 +345,7 @@ static void smemstat_top_printf(const char *fmt, ...)
 	if (n > sz)
 		n = sz;
 	buf[n] = '\0';
-	(void)mvprintw(cury, 0, buf);
+	(void)mvprintw(cury, 0, "%s", buf);
 	va_end(ap);
 	cury++;
 }


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    smemstat.c:348:33: error: format not a string literal and no format arguments [-Werror=format-security]
      348 |         (void)mvprintw(cury, 0, buf);
          |                                 ^~~

Let's wrap all the missing places with "%s" format.